### PR TITLE
Integrator Abstraction

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,7 @@ add_executable(test_variable_drag_supersonic src/test_variable_drag_supersonic.c
 add_executable(example_3d_motion src/example_3d_motion.cpp)
 add_executable(test_golf_ball src/test_golf_ball.cpp ${COMMON_SOURCES})
 add_executable(test_adaptive src/test_adaptive.cpp ${COMMON_SOURCES})
+add_executable(test_convergence src/test_convergence.cpp ${COMMON_SOURCES})
 
 # Include directories
 target_include_directories(main PRIVATE include)
@@ -28,3 +29,4 @@ target_include_directories(test_variable_drag_supersonic PRIVATE include)
 target_include_directories(example_3d_motion PRIVATE include)
 target_include_directories(test_golf_ball PRIVATE include)
 target_include_directories(test_adaptive PRIVATE include)
+target_include_directories(test_convergence PRIVATE include)

--- a/README.md
+++ b/README.md
@@ -333,6 +333,11 @@ To find the launch angle $\theta$ that maximizes horizontal distance $x_{impact}
      ./test_golf_ball
      ```
 
+   - **`test_convergence`** — Empirical order-of-convergence test for the five fixed-step integrators. Runs each at progressively halved dt values against an ultra-precise RK8 reference and reports the error ratios and `log2(ratio)` empirical orders. Recovers theoretical orders 1, 2, 4, 5, 8 for Euler, Heun, RK4, RK45, and RK8 respectively (asymptotically, before the floating-point precision floor).
+     ```sh
+     ./test_convergence
+     ```
+
    - **`test_adaptive`** — Demonstrates the adaptive RK45 integrator on a golf-ball trajectory at two error tolerances. Reports accepted/rejected step counts, achieved min/max dt range, and final flight distance.
      ```sh
      ./test_adaptive
@@ -380,6 +385,11 @@ clang++ -std=c++14 -O3 -I include -o test_golf_ball src/test_golf_ball.cpp src/s
 **Adaptive RK45 Demo:**
 ```sh
 clang++ -std=c++14 -O3 -I include -o test_adaptive src/test_adaptive.cpp src/simulation.cpp src/derivative_functions.cpp
+```
+
+**Convergence Order Test:**
+```sh
+clang++ -std=c++14 -O3 -I include -o test_convergence src/test_convergence.cpp src/simulation.cpp src/derivative_functions.cpp
 ```
 
 **3D Motion Demo:**

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Below are calculated `k_over_m` values for common objects, assuming standard sea
   - **Euler (1st Order)**: Basic forward stepping method used as a baseline. Simple but requires extremely small time steps for accuracy.
   - **Heun (2nd Order)**: Also known as the trapezoidal method. Offers improved stability over Euler.
   - **RK4 (4th Order)**: The classic Runge-Kutta method. Provides an excellent balance of speed and accuracy; used as the default engine.
-  - **RK45 (Dormand-Prince)**: An embedded 5(4) method that provides error estimation. Used for adaptive stepping (variable dt) or high-precision fixed stepping.
+  - **RK45 (Dormand-Prince)**: An embedded 5(4) method available in two variants — `rk45_step` (fixed dt, high-precision) and `rk45_adaptive_step` (returns an error estimate alongside the new state for step-size control). Both share the same 7-stage tableau.
   - **RK8 (8th Order)**: High-order method requiring 13 function evaluations per step. Extremely accurate, used as the "Ground Truth" for benchmarking other methods.
 - **Event Detection**: The main simulation loop terminates when the vertical position $y < 0$. To determine the exact impact location, the program performs a linear interpolation between the last state above ground and the current state below ground.
 
@@ -158,7 +158,7 @@ To find the launch angle $\theta$ that maximizes horizontal distance $x_{impact}
 5. **Run Unit Tests**:
    Executes a suite of validation tests to ensure physics engine accuracy.
    - **Vacuum Test**: Verifies $\theta_{opt} \approx 45^\circ$ for all integrators when drag is zero.
-   - **Consistency Test**: Cross-references lower-order integrators (Euler, Heun) against the high-precision RK8 method to ensure results are within expected convergence limits under drag conditions.
+   - **Consistency Test**: Cross-references lower-order integrators (Euler, Heun, RK4) against the high-precision RK8 method to ensure results are within expected convergence limits under drag conditions.
    ```sh
    ./test
    ```
@@ -324,6 +324,25 @@ To find the launch angle $\theta$ that maximizes horizontal distance $x_{impact}
      Angle Shift:     1.60 degrees (variable Cd - constant Cd)
    ```
 
+8. **Additional Executables**:
+
+   Three more programs ship in `build/` for specialized demonstrations:
+
+   - **`test_golf_ball`** — Compares optimal-angle trajectories under three golf-ball drag models: vacuum, constant-Cd v² drag, and velocity-dependent Cd that transitions from laminar to turbulent across the 18-25 m/s range.
+     ```sh
+     ./test_golf_ball
+     ```
+
+   - **`test_adaptive`** — Demonstrates the adaptive RK45 integrator on a golf-ball trajectory at two error tolerances. Reports accepted/rejected step counts, achieved min/max dt range, and final flight distance.
+     ```sh
+     ./test_adaptive
+     ```
+
+   - **`example_3d_motion`** — Standalone 3D-projectile demo using the 6-DOF `State6D = [x, y, z, vx, vy, vz]`. Confirms that the integrator templates accept arbitrary state dimensions, not just the 4-DOF state used by the projectile motion code.
+     ```sh
+     ./example_3d_motion
+     ```
+
 ## Help
 
 If CMake is not available, you can compile the individual programs manually using a C++14 compiler.
@@ -351,6 +370,21 @@ clang++ -std=c++14 -O3 -I include -o compare_k_over_m src/compare_k_over_m.cpp s
 **Supersonic Variable Drag Analysis:**
 ```sh
 clang++ -std=c++14 -O3 -I include -o test_variable_drag_supersonic src/test_variable_drag_supersonic.cpp src/simulation.cpp src/derivative_functions.cpp
+```
+
+**Golf Ball Drag Transition Test:**
+```sh
+clang++ -std=c++14 -O3 -I include -o test_golf_ball src/test_golf_ball.cpp src/simulation.cpp src/derivative_functions.cpp
+```
+
+**Adaptive RK45 Demo:**
+```sh
+clang++ -std=c++14 -O3 -I include -o test_adaptive src/test_adaptive.cpp src/simulation.cpp src/derivative_functions.cpp
+```
+
+**3D Motion Demo:**
+```sh
+clang++ -std=c++14 -O3 -I include -o example_3d_motion src/example_3d_motion.cpp
 ```
 
 ## Authors

--- a/include/derivative_functions.hpp
+++ b/include/derivative_functions.hpp
@@ -3,14 +3,25 @@
 
 #include "types.hpp"
 
-void drag_deriv_v_squared(const State4D& s, double t, State4D& deriv, double g, double k_over_m);
+// Problem-specific context bundle for projectile-motion derivatives.
+// Bundled into the generic ParameterizedDerivative<State, Context> signature
+// so the framework never sees projectile-specific parameters.
+struct ProjectileContext {
+    double g;        // gravitational acceleration (m/s^2)
+    double k_over_m; // drag coefficient ratio (k/m)
+};
 
-void drag_deriv_linear(const State4D& s, double t, State4D& deriv, double g, double k_over_m);
+// Convenience alias for the projectile-motion derivative signature.
+using ProjectileDerivative = ParameterizedDerivative<State4D, ProjectileContext>;
 
-void no_drag_deriv(const State4D& s, double t, State4D& deriv, double g, double k_over_m = 0.0);
+void drag_deriv_v_squared(const State4D& s, double t, State4D& deriv, const ProjectileContext& ctx);
 
-void golf_ball_drag_deriv(const State4D& s, double t, State4D& deriv, double g, double);
+void drag_deriv_linear(const State4D& s, double t, State4D& deriv, const ProjectileContext& ctx);
 
-void variable_drag_deriv(const State4D& s, double t, State4D& deriv, double g, double base_k_over_m);
+void no_drag_deriv(const State4D& s, double t, State4D& deriv, const ProjectileContext& ctx);
+
+void golf_ball_drag_deriv(const State4D& s, double t, State4D& deriv, const ProjectileContext& ctx);
+
+void variable_drag_deriv(const State4D& s, double t, State4D& deriv, const ProjectileContext& ctx);
 
 #endif // DERIVATIVE_FUNCTIONS_HPP

--- a/include/integrators.hpp
+++ b/include/integrators.hpp
@@ -16,13 +16,13 @@ using SystemIntegrator = std::function<State(const State& current_state, double 
 // integrator: one set per thread per template instantiation, lazily sized from
 // the input state on the first call, then reused across subsequent calls.
 //
-// For runtime-sized containers (std::vector<double>) this eliminates per-step
-// heap allocation of the stage workspace — substantial savings when many steps
-// run. For compile-time-sized containers (std::array<double, N>) the size
-// check folds to a compile-time constant and the conditional initialization
-// is elided — zero runtime overhead vs. plain local declarations.
+// For runtime-sized containers (std::vector<double>) this avoids per-step heap
+// allocation of the stage workspace — substantial savings when many steps run.
+// For compile-time-sized containers (std::array<double, N>) the size check
+// folds to a compile-time constant and the conditional initialization is
+// elided.
 //
-// Return values (next_state, result.state, result.error) remain plain locals so
+// Return values (next_state, result.state, result.error) are plain locals so
 // that RVO/NRVO can construct the caller's destination directly, avoiding an
 // extra copy on the return path.
 //

--- a/include/integrators.hpp
+++ b/include/integrators.hpp
@@ -12,13 +12,20 @@ using SystemDerivative = std::function<void(const State& current_state, double c
 template <typename State>
 using SystemIntegrator = std::function<State(const State& current_state, double current_time, double time_step, SystemDerivative<State> derivative_func)>;
 
+// State temporaries (k1, k2, ..., next_state) are initialized via `= state` rather than
+// default-constructed. This sizes runtime-sized containers (e.g. std::vector<double>) to
+// match the input state. For compile-time-sized containers (e.g. std::array<double, N>)
+// it copies a small fixed number of doubles that get overwritten anyway — typically
+// optimized away. Without this, vector-backed states crash because `State foo;`
+// default-constructs an empty vector and `foo[i] = ...` is undefined behavior.
+
 //Forward Euler (Explicit Euler)
 template<typename State, typename DerivativeFunc>
 State euler_step(const State& state, double t, double dt, DerivativeFunc deriv_func) {
-    State deriv;
+    State deriv = state;
     deriv_func(state, t, deriv);
-    
-    State next_state;
+
+    State next_state = state;
     for (size_t i = 0; i < state.size(); ++i) {
         next_state[i] = state[i] + dt * deriv[i];
     }
@@ -29,15 +36,15 @@ State euler_step(const State& state, double t, double dt, DerivativeFunc deriv_f
 //Heun's Method (Trapezoidal Rule)
 template<typename State, typename DerivativeFunc>
 State heun_step(const State& state, double t, double dt, DerivativeFunc deriv_func) {
-    State k1, k2, temp;
-    
+    State k1 = state, k2 = state, temp = state;
+
     deriv_func(state, t, k1);
     for (size_t i = 0; i < state.size(); ++i) {
         temp[i] = state[i] + dt * k1[i];
     }
-    
+
     deriv_func(temp, t + dt, k2);
-    State next_state;
+    State next_state = state;
     for (size_t i = 0; i < state.size(); ++i) {
         next_state[i] = state[i] + 0.5 * dt * (k1[i] + k2[i]);
     }
@@ -60,27 +67,27 @@ State heun_step(const State& state, double t, double dt, DerivativeFunc deriv_fu
 // which essentially cancels out lower-order error terms.
 template<typename State, typename DerivativeFunc>
 State rk4_step(const State& state, double t, double dt, DerivativeFunc deriv_func) {
-    State k1, k2, k3, k4, temp;
-    
+    State k1 = state, k2 = state, k3 = state, k4 = state, temp = state;
+
     // Stage 1: Derivative at the start
     deriv_func(state, t, k1);
     for (size_t i = 0; i < state.size(); ++i)
         temp[i] = state[i] + 0.5 * dt * k1[i];
-    
+
     // Stage 2: Derivative at midpoint (based on k1)
     deriv_func(temp, t + 0.5*dt, k2);
     for (size_t i = 0; i < state.size(); ++i)
         temp[i] = state[i] + 0.5 * dt * k2[i];
-    
+
     // Stage 3: Derivative at midpoint (based on k2)
-    // Note: We sample at the *same time* (t + 0.5*dt) as Stage 2. 
+    // Note: We sample at the *same time* (t + 0.5*dt) as Stage 2.
     // The difference is that we use k2 (the improved slope estimate) to reach this point, rather than k1.
     deriv_func(temp, t + 0.5*dt, k3);
     for (size_t i = 0; i < state.size(); ++i)
         temp[i] = state[i] + dt * k3[i];
-    
+
     // Stage 4: Derivative at end (based on k3)
-    // We estimate the state at the end of the interval (t + dt) by projecting 
+    // We estimate the state at the end of the interval (t + dt) by projecting
     // from the start using the refined midpoint slope (k3) across the full step dt.
     deriv_func(temp, t + dt, k4);
 
@@ -88,7 +95,7 @@ State rk4_step(const State& state, double t, double dt, DerivativeFunc deriv_fun
     // We compute the true next state by taking a weighted average of the four slopes.
     // k1, k4 (endpoints) get weight 1.
     // k2, k3 (midpoints) get weight 2.
-    State next_state;
+    State next_state = state;
     for (size_t i = 0; i < state.size(); ++i) {
         next_state[i] = state[i] + (dt/6.0) * (k1[i] + 2*k2[i] + 2*k3[i] + k4[i]);
     }
@@ -204,6 +211,7 @@ namespace rk45_detail {
 template<typename State, typename DerivativeFunc>
 State rk45_step(const State& state, double t, double dt, DerivativeFunc deriv_func) {
     State k[7];
+    for (auto& ki : k) ki = state;  // Size each stage to match input state.
     rk45_detail::compute_stages(state, t, dt, deriv_func, k);
 
     State next_state = state;
@@ -243,11 +251,13 @@ struct AdaptiveStepResult {
 template<typename State, typename DerivativeFunc>
 AdaptiveStepResult<State> rk45_adaptive_step(const State& state, double t, double dt, DerivativeFunc deriv_func) {
     State k[7];
+    for (auto& ki : k) ki = state;  // Size each stage to match input state.
     rk45_detail::compute_stages(state, t, dt, deriv_func, k);
 
     AdaptiveStepResult<State> result;
     result.state = state;
-    
+    result.error = state;  // Size error to match state; values overwritten by the loop below.
+
     // Initialize error with zeros
     for(size_t s=0; s<state.size(); ++s) {
         result.error[s] = 0.0;
@@ -355,8 +365,9 @@ State rk8_step(const State& state, double t, double dt, DerivativeFunc deriv_fun
     };
     
     State k[13];
-    State temp_state;
-    
+    for (auto& ki : k) ki = state;  // Size each stage to match input state.
+    State temp_state = state;
+
     // Stage 1
     deriv_func(state, t, k[0]);
     

--- a/include/integrators.hpp
+++ b/include/integrators.hpp
@@ -12,17 +12,31 @@ using SystemDerivative = std::function<void(const State& current_state, double c
 template <typename State>
 using SystemIntegrator = std::function<State(const State& current_state, double current_time, double time_step, SystemDerivative<State> derivative_func)>;
 
-// State temporaries (k1, k2, ..., next_state) are initialized via `= state` rather than
-// default-constructed. This sizes runtime-sized containers (e.g. std::vector<double>) to
-// match the input state. For compile-time-sized containers (e.g. std::array<double, N>)
-// it copies a small fixed number of doubles that get overwritten anyway — typically
-// optimized away. Without this, vector-backed states crash because `State foo;`
-// default-constructs an empty vector and `foo[i] = ...` is undefined behavior.
+// Stage temporaries (k1, k2, ..., temp) are declared thread_local inside each
+// integrator: one set per thread per template instantiation, lazily sized from
+// the input state on the first call, then reused across subsequent calls.
+//
+// For runtime-sized containers (std::vector<double>) this eliminates per-step
+// heap allocation of the stage workspace — substantial savings when many steps
+// run. For compile-time-sized containers (std::array<double, N>) the size
+// check folds to a compile-time constant and the conditional initialization
+// is elided — zero runtime overhead vs. plain local declarations.
+//
+// Return values (next_state, result.state, result.error) remain plain locals so
+// that RVO/NRVO can construct the caller's destination directly, avoiding an
+// extra copy on the return path.
+//
+// Constraint: thread_local workspace is shared across all invocations on the
+// same thread. The integrators must NOT be invoked recursively (e.g., a
+// derivative function calling the same integrator) — that would clobber the
+// in-flight workspace. Standard numerical integration patterns never do this.
 
 //Forward Euler (Explicit Euler)
 template<typename State, typename DerivativeFunc>
 State euler_step(const State& state, double t, double dt, DerivativeFunc deriv_func) {
-    State deriv = state;
+    thread_local State deriv;
+    if (deriv.size() != state.size()) { deriv = state; }
+
     deriv_func(state, t, deriv);
 
     State next_state = state;
@@ -36,7 +50,8 @@ State euler_step(const State& state, double t, double dt, DerivativeFunc deriv_f
 //Heun's Method (Trapezoidal Rule)
 template<typename State, typename DerivativeFunc>
 State heun_step(const State& state, double t, double dt, DerivativeFunc deriv_func) {
-    State k1 = state, k2 = state, temp = state;
+    thread_local State k1, k2, temp;
+    if (k1.size() != state.size()) { k1 = state; k2 = state; temp = state; }
 
     deriv_func(state, t, k1);
     for (size_t i = 0; i < state.size(); ++i) {
@@ -67,7 +82,8 @@ State heun_step(const State& state, double t, double dt, DerivativeFunc deriv_fu
 // which essentially cancels out lower-order error terms.
 template<typename State, typename DerivativeFunc>
 State rk4_step(const State& state, double t, double dt, DerivativeFunc deriv_func) {
-    State k1 = state, k2 = state, k3 = state, k4 = state, temp = state;
+    thread_local State k1, k2, k3, k4, temp;
+    if (k1.size() != state.size()) { k1 = state; k2 = state; k3 = state; k4 = state; temp = state; }
 
     // Stage 1: Derivative at the start
     deriv_func(state, t, k1);
@@ -185,7 +201,9 @@ namespace rk45_detail {
     // curvature of the function and are shared by both the 4th and 5th order solutions.
     template<typename State, typename DerivativeFunc>
     void compute_stages(const State& state, double t, double dt, DerivativeFunc deriv_func, State (&k)[7]) {
-        State temp;
+        thread_local State temp;
+        if (temp.size() != state.size()) { temp = state; }
+
         deriv_func(state, t, k[0]);
 
         for (int i = 1; i < 7; ++i) {
@@ -210,8 +228,9 @@ namespace rk45_detail {
 // fixed-step integrator, but with 5th-order accuracy (6 evaluations per step).
 template<typename State, typename DerivativeFunc>
 State rk45_step(const State& state, double t, double dt, DerivativeFunc deriv_func) {
-    State k[7];
-    for (auto& ki : k) ki = state;  // Size each stage to match input state.
+    thread_local State k[7];
+    if (k[0].size() != state.size()) { for (auto& ki : k) ki = state; }
+
     rk45_detail::compute_stages(state, t, dt, deriv_func, k);
 
     State next_state = state;
@@ -250,15 +269,19 @@ struct AdaptiveStepResult {
 // on straightaways (linear dynamics), ensuring efficiency and accuracy.
 template<typename State, typename DerivativeFunc>
 AdaptiveStepResult<State> rk45_adaptive_step(const State& state, double t, double dt, DerivativeFunc deriv_func) {
-    State k[7];
-    for (auto& ki : k) ki = state;  // Size each stage to match input state.
+    thread_local State k[7];
+    if (k[0].size() != state.size()) { for (auto& ki : k) ki = state; }
+
     rk45_detail::compute_stages(state, t, dt, deriv_func, k);
 
+    // Return-value members sized from the input state. `result.state` is then
+    // accumulated into by the 5th-order weighting loop below; `result.error`
+    // is explicitly zeroed first so the difference-coeffs loop accumulates
+    // cleanly.
     AdaptiveStepResult<State> result;
     result.state = state;
-    result.error = state;  // Size error to match state; values overwritten by the loop below.
+    result.error = state;
 
-    // Initialize error with zeros
     for(size_t s=0; s<state.size(); ++s) {
         result.error[s] = 0.0;
     }
@@ -364,9 +387,12 @@ State rk8_step(const State& state, double t, double dt, DerivativeFunc deriv_fun
         -528747749.0/2220607170.0, 1.0/4.0
     };
     
-    State k[13];
-    for (auto& ki : k) ki = state;  // Size each stage to match input state.
-    State temp_state = state;
+    thread_local State k[13];
+    thread_local State temp_state;
+    if (k[0].size() != state.size()) {
+        for (auto& ki : k) ki = state;
+        temp_state = state;
+    }
 
     // Stage 1
     deriv_func(state, t, k[0]);

--- a/include/simulation.hpp
+++ b/include/simulation.hpp
@@ -19,7 +19,7 @@ public:
     Simulation(double k_over_m,
                SystemIntegrator<State4D> integrator,
                double v0 = 100.0,
-               DerivativeFuncPtr derivative = drag_deriv_v_squared,
+               ProjectileDerivative derivative = drag_deriv_v_squared,
                double g = 9.81,
                double h0 = 0.0);
 

--- a/include/types.hpp
+++ b/include/types.hpp
@@ -2,26 +2,68 @@
 #define TYPES_HPP
 
 #include <array>
+#include <vector>
 #include <functional>
 
-// 4D State Indices (Namespaced)
+// State containers ----------------------------------------------------------
+// The framework treats the simulation state as an opaque flat container of
+// doubles; interpretation of the slots is owned by each problem domain.
+//
+// FixedState<N>: compile-time size, stack-allocated, trivially copyable.
+//                Use when N is small and known at build time (projectile
+//                motion, demos, anything where N is a handful).
+// DynamicState:  runtime-sized, heap-backed. Use when N is determined at
+//                runtime, varies between runs of the same binary, or is too
+//                large to live on the stack.
+//
+// Integrator templates iterate via .size() and operator[], so they accept
+// either container uniformly.
+
+template <std::size_t N>
+using FixedState = std::array<double, N>;
+
+using DynamicState = std::vector<double>;
+
+// Projectile-motion state shapes used in this repo. New problem domains
+// should declare their own typedef in terms of FixedState<N> or DynamicState.
+using State4D = FixedState<4>;  // [x, y, vx, vy]
+using State6D = FixedState<6>;  // [x, y, z, vx, vy, vz]
+
+
+// State interpretation (problem-specific) -----------------------------------
+// Anonymous-enum-in-namespace gives named, scoped integer indices into the
+// flat state array. Each problem domain provides its own mapping; the
+// framework itself never reads these.
+
 namespace StateIndex4D {
     enum { X_POS = 0, Y_POS = 1, X_VEL = 2, Y_VEL = 3 };
 }
 
-// 6D State Indices (Namespaced)
 namespace StateIndex6D {
     enum { X_POS = 0, Y_POS = 1, Z_POS = 2, X_VEL = 3, Y_VEL = 4, Z_VEL = 5 };
 }
 
-// 4D state: [x_pos, y_pos, x_vel, y_vel]
-using State4D = std::array<double, 4>;
 
-// 6D state: [x, y, z, vx, vy, vz]
-using State6D = std::array<double, 6>;
+// Derivative-function signatures --------------------------------------------
+// Generic, interpretation-neutral form: takes (state, t, deriv_out, ctx)
+// where Context is whatever problem-specific parameter bundle the derivative
+// needs (gravity + drag for projectile motion; constants + masses for an
+// N-body system; anything else for some other problem). The framework never
+// inspects Context — it just passes it through to the bound derivative.
 
-// Specific physics model (forces/derivatives) including physical constants. 
-// Bound into a SystemDerivative within the Simulation class.
-using DerivativeFuncPtr = std::function<void(const State4D& current_state, double current_time, State4D& derivative_output, double gravity, double k_over_m)>;
+template <typename State, typename Context>
+using ParameterizedDerivative =
+    std::function<void(const State& state, double t, State& deriv_out, const Context& ctx)>;
+
+// Projectile-specific signature with positional (g, k_over_m) parameters.
+// Retained for source-compatibility with the existing derivative functions
+// and Simulation class. New code should prefer ParameterizedDerivative<>
+// with a problem-specific Context struct.
+using DerivativeFuncPtr = std::function<void(
+    const State4D& current_state,
+    double         current_time,
+    State4D&       derivative_output,
+    double         gravity,
+    double         k_over_m)>;
 
 #endif // TYPES_HPP

--- a/include/types.hpp
+++ b/include/types.hpp
@@ -55,15 +55,4 @@ template <typename State, typename Context>
 using ParameterizedDerivative =
     std::function<void(const State& state, double t, State& deriv_out, const Context& ctx)>;
 
-// Projectile-specific signature with positional (g, k_over_m) parameters.
-// Retained for source-compatibility with the existing derivative functions
-// and Simulation class. New code should prefer ParameterizedDerivative<>
-// with a problem-specific Context struct.
-using DerivativeFuncPtr = std::function<void(
-    const State4D& current_state,
-    double         current_time,
-    State4D&       derivative_output,
-    double         gravity,
-    double         k_over_m)>;
-
 #endif // TYPES_HPP

--- a/src/compare_integrators.cpp
+++ b/src/compare_integrators.cpp
@@ -53,9 +53,10 @@ int main() {
         State4D state = {0.0, h0, v0 * std::cos(angle_rad), v0 * std::sin(angle_rad)};
         double t = 0.0;
         
-        // Lambda to bind parameters
-        auto bound_deriv = [&](const State4D& s, double time, State4D& out_d) {
-             drag_deriv_v_squared(s, time, out_d, g, k_over_m);
+        // Lambda to bind parameters via a ProjectileContext
+        ProjectileContext ctx{g, k_over_m};
+        auto bound_deriv = [&ctx](const State4D& s, double time, State4D& out_d) {
+             drag_deriv_v_squared(s, time, out_d, ctx);
         };
 
         long long steps = std::round(t_end / dt);

--- a/src/derivative_functions.cpp
+++ b/src/derivative_functions.cpp
@@ -14,8 +14,8 @@
  * - variable_drag:    Mach-dependent Cd with transonic rise and supersonic fade.
  *
  * All models follow the ParameterizedDerivative<State4D, ProjectileContext>
- * signature; projectile-specific parameters (g, k/m) are bundled in the
- * ProjectileContext rather than passed as positional doubles.
+ * signature; projectile-specific parameters (g, k/m) are carried in the
+ * ProjectileContext bundle.
  */
 #include "../include/derivative_functions.hpp"
 #include "../include/types.hpp"

--- a/src/derivative_functions.cpp
+++ b/src/derivative_functions.cpp
@@ -7,41 +7,47 @@
  * the numerical integrators to evolve the system state over time.
  *
  * Supported Models:
- * - v_squared_drag: Standard quadratic air resistance (F_drag ~ v^2).
- * - linear_drag: Linear air resistance (F_drag ~ v), useful for Stokes' law regime.
- * - no_drag: Vacuum trajectory, theoretical baseline.
+ * - v_squared_drag:   Standard quadratic air resistance (F_drag ~ v^2).
+ * - linear_drag:      Linear air resistance (F_drag ~ v), useful for Stokes' law regime.
+ * - no_drag:          Vacuum trajectory, theoretical baseline.
+ * - golf_ball_drag:   Velocity-dependent laminar/turbulent Cd transition.
+ * - variable_drag:    Mach-dependent Cd with transonic rise and supersonic fade.
+ *
+ * All models follow the ParameterizedDerivative<State4D, ProjectileContext>
+ * signature; projectile-specific parameters (g, k/m) are bundled in the
+ * ProjectileContext rather than passed as positional doubles.
  */
 #include "../include/derivative_functions.hpp"
 #include "../include/types.hpp"
 #include "../include/constants.hpp"
 #include <cmath>
 
-void drag_deriv_v_squared(const State4D& s, double t, State4D& deriv, double g, double k_over_m) {
+void drag_deriv_v_squared(const State4D& s, double t, State4D& deriv, const ProjectileContext& ctx) {
     using namespace StateIndex4D;
     const double v = std::sqrt(s[X_VEL]*s[X_VEL] + s[Y_VEL]*s[Y_VEL]);
     deriv[X_POS] = s[X_VEL];  // dx/dt = vx
     deriv[Y_POS] = s[Y_VEL];  // dy/dt = vy
-    deriv[X_VEL] = -k_over_m * v * s[X_VEL];  // dvx/dt = -k/m * v * vx
-    deriv[Y_VEL] = -g - k_over_m * v * s[Y_VEL];  // dvy/dt = -g -k/m * v * vy
+    deriv[X_VEL] = -ctx.k_over_m * v * s[X_VEL];          // dvx/dt = -k/m * v * vx
+    deriv[Y_VEL] = -ctx.g - ctx.k_over_m * v * s[Y_VEL];  // dvy/dt = -g -k/m * v * vy
 }
 
-void drag_deriv_linear(const State4D& s, double t, State4D& deriv, double g, double k_over_m) {
+void drag_deriv_linear(const State4D& s, double t, State4D& deriv, const ProjectileContext& ctx) {
     using namespace StateIndex4D;
     deriv[X_POS] = s[X_VEL];  // dx/dt = vx
     deriv[Y_POS] = s[Y_VEL];  // dy/dt = vy
-    deriv[X_VEL] = -k_over_m * s[X_VEL];  // dvx/dt = -k/m * vx
-    deriv[Y_VEL] = -g - k_over_m * s[Y_VEL];  // dvy/dt = -g -k/m * vy
+    deriv[X_VEL] = -ctx.k_over_m * s[X_VEL];          // dvx/dt = -k/m * vx
+    deriv[Y_VEL] = -ctx.g - ctx.k_over_m * s[Y_VEL];  // dvy/dt = -g -k/m * vy
 }
 
-void no_drag_deriv(const State4D& s, double t, State4D& deriv, double g, double) {
+void no_drag_deriv(const State4D& s, double t, State4D& deriv, const ProjectileContext& ctx) {
     using namespace StateIndex4D;
     deriv[X_POS] = s[X_VEL];  // dx/dt = vx
     deriv[Y_POS] = s[Y_VEL];  // dy/dt = vy
     deriv[X_VEL] = 0.0;       // dvx/dt = 0
-    deriv[Y_VEL] = -g;        // dvy/dt = -g
+    deriv[Y_VEL] = -ctx.g;    // dvy/dt = -g
 }
 
-void variable_drag_deriv(const State4D& s, double t, State4D& deriv, double g, double base_k_over_m) {
+void variable_drag_deriv(const State4D& s, double t, State4D& deriv, const ProjectileContext& ctx) {
     using namespace StateIndex4D;
     // 1. Calculate current speed from State
     double v_sq = s[X_VEL]*s[X_VEL] + s[Y_VEL]*s[Y_VEL];
@@ -64,19 +70,19 @@ void variable_drag_deriv(const State4D& s, double t, State4D& deriv, double g, d
         // Note: Realistically it might stay higher, but we fade to base here
         drag_multiplier = 1.0;
     }
-    
-    double current_k_over_m = base_k_over_m * drag_multiplier;
+
+    double current_k_over_m = ctx.k_over_m * drag_multiplier;
 
     // 3. Apply force
     deriv[X_POS] = s[X_VEL];
     deriv[Y_POS] = s[Y_VEL];
-    
+
     // Apply drag acceleration
     deriv[X_VEL] = -current_k_over_m * v * s[X_VEL];
-    deriv[Y_VEL] = -g - current_k_over_m * v * s[Y_VEL];
+    deriv[Y_VEL] = -ctx.g - current_k_over_m * v * s[Y_VEL];
 }
 
-void golf_ball_drag_deriv(const State4D& s, double t, State4D& deriv, double g, double v_critical) {
+void golf_ball_drag_deriv(const State4D& s, double t, State4D& deriv, const ProjectileContext& ctx) {
     using namespace StateIndex4D;
 
     // 1. Calculate Velocity
@@ -85,7 +91,7 @@ void golf_ball_drag_deriv(const State4D& s, double t, State4D& deriv, double g, 
 
     // 2. Determine Cd based on Velocity
     double Cd;
-    
+
     // Use Shared Constants
     const double v_start = GolfBallPhysics::V_TRANSITION_START;
     const double v_end = GolfBallPhysics::V_TRANSITION_END;
@@ -103,12 +109,13 @@ void golf_ball_drag_deriv(const State4D& s, double t, State4D& deriv, double g, 
         Cd = Cd_final;
     }
 
-    // 3. Calculate dynamic k/m
+    // 3. Calculate dynamic k/m. Note: ctx.k_over_m is ignored — this model
+    // derives drag entirely from GolfBallPhysics constants.
     double current_k_over_m = GolfBallPhysics::FACTOR_F * Cd;
 
     // 4. Apply derivatives
     deriv[X_POS] = s[X_VEL];
     deriv[Y_POS] = s[Y_VEL];
     deriv[X_VEL] = -current_k_over_m * v * s[X_VEL];
-    deriv[Y_VEL] = -g - current_k_over_m * v * s[Y_VEL];
+    deriv[Y_VEL] = -ctx.g - current_k_over_m * v * s[Y_VEL];
 }

--- a/src/derivative_functions.cpp
+++ b/src/derivative_functions.cpp
@@ -60,7 +60,7 @@ void variable_drag_deriv(const State4D& s, double t, State4D& deriv, double g, d
         // Linear decay: (mach - 1.0) / 1.0 gives 0..1 fraction
         drag_multiplier = 2.5 - ((mach - 1.0) / 1.0) * 1.5;
     } else if (mach >= 2.0) {
-        // Settled back to base at high mach (per request)
+        // Settled back to base at high mach
         // Note: Realistically it might stay higher, but we fade to base here
         drag_multiplier = 1.0;
     }

--- a/src/simulation.cpp
+++ b/src/simulation.cpp
@@ -18,17 +18,18 @@
 Simulation::Simulation(double k_over_m,
                        SystemIntegrator<State4D> integrator,
                        double v0,
-                       DerivativeFuncPtr derivative,
+                       ProjectileDerivative derivative,
                        double g,
                        double h0)
     : g_(g),
       k_over_m_(k_over_m),
       v0_(v0),
       h0_(h0),
-      stepper_([integrator, derivative, g, k_over_m](const State4D& s, double t, double dt) -> State4D {
-        // Lambda to match SystemDerivative signature
-        auto bound_deriv = [derivative, g, k_over_m](const State4D& state, double time, State4D& out_d) {
-             derivative(state, time, out_d, g, k_over_m); 
+      stepper_([integrator, derivative, ctx = ProjectileContext{g, k_over_m}](const State4D& s, double t, double dt) -> State4D {
+        // Bind the ProjectileContext into a SystemDerivative<State4D>-shaped callable
+        // that the dimension-generic integrator expects.
+        auto bound_deriv = [derivative, &ctx](const State4D& state, double time, State4D& out_d) {
+             derivative(state, time, out_d, ctx);
         };
         return integrator(s, t, dt, bound_deriv);
     }) {

--- a/src/test.cpp
+++ b/src/test.cpp
@@ -39,7 +39,7 @@ struct IntegratorInfo {
 // Define a struct to hold derivative function information
 struct DerivativeInfo {
     std::string name;
-    DerivativeFuncPtr func;
+    ProjectileDerivative func;
 };
 
 int main() {

--- a/src/test_adaptive.cpp
+++ b/src/test_adaptive.cpp
@@ -32,10 +32,9 @@ void run_adaptive_simulation(double tolerance) {
     const double h0 = 0.0;
     
     // Golf ball physics constants are handled inside the derivative function
-    // But we need to pass a dummy dummy k/m or v_critical if the signature requires it.
-    // golf_ball_drag_deriv signature: (s, t, deriv, g, v_critical)
-    // We'll hardcode v_critical inside the loop or pass 0 if it's unused (the function uses shared constants)
-    const double dummy_param = 0.0; 
+    // golf_ball_drag_deriv reads g from the context; k_over_m is unused
+    // because the model derives drag entirely from GolfBallPhysics constants.
+    ProjectileContext ctx{g, 0.0};
 
     // Setup State
     State4D state = {0.0, h0, v0 * std::cos(angle_rad), v0 * std::sin(angle_rad)};
@@ -54,8 +53,8 @@ void run_adaptive_simulation(double tolerance) {
     std::cout << "-----------------------------------------------------\n";
 
     // Lambda for derivative to match signature expected by rk45_adaptive_step
-    auto deriv_func = [&](const State4D& s, double time, State4D& out) {
-        golf_ball_drag_deriv(s, time, out, g, dummy_param);
+    auto deriv_func = [&ctx](const State4D& s, double time, State4D& out) {
+        golf_ball_drag_deriv(s, time, out, ctx);
     };
 
     while (state[Y_POS] >= 0.0) {

--- a/src/test_golf_ball.cpp
+++ b/src/test_golf_ball.cpp
@@ -11,7 +11,7 @@
 #include "../include/golden_section.hpp"
 
 // Optimize angle for a given configuration and print results
-void run_optimization_case(std::string label, double v0, double k_over_m, DerivativeFuncPtr deriv_func) {
+void run_optimization_case(std::string label, double v0, double k_over_m, ProjectileDerivative deriv_func) {
     const double g = GRAVITY_EARTH;
     const double dt = 0.001; 
     const double h0 = 0.0;


### PR DESCRIPTION
# Abstraction layer for size-portable, problem-agnostic ODE integration

This PR advances the codebase from a projectile-motion-specific integrator framework
toward a generic, container-agnostic ODE integration framework. The integrator templates
now accept any container shape (`std::array` or `std::vector`) and the derivative
signature is parameterized on an opaque problem-specific context type. Projectile motion
becomes one application of the framework rather than the framework itself.

A new test executable measures empirical convergence orders for each integrator,
recovering the textbook theoretical orders (1, 2, 4, 5, 8) on a smooth-drag problem.

## Motivation

The original integrator templates (`euler_step`, `heun_step`, `rk4_step`, `rk45_step`,
`rk45_adaptive_step`, `rk8_step`) compiled cleanly for any State type exposing `.size()`
and `operator[]`, but in practice carried two hidden assumptions:

1. The derivative signature was hardcoded to projectile parameters
   (`(state, t, deriv, double g, double k_over_m)`), making it impossible to plug in a
   problem with different parameters (gravitational masses, Lorentz forces, lift
   coefficients, etc.) without forking the integrator code.
2. Stage temporaries were default-constructed (`State k1;`) — fine for
   `std::array<double, N>` (default-construction yields N uninitialized doubles, ready
   to write) but crashes for `std::vector<double>` (default-construction yields an
   empty vector, and `[i] = ...` is undefined behavior).

These limitations blocked any future use beyond the existing 2D/3D projectile setup —
e.g., flexible-N state vectors, problem-specific parameter bundles, or runtime-sized
state for larger simulations.

## What changed

### Framework-neutral type primitives

Three new generic aliases in `types.hpp` alongside the existing `State4D`/`State6D`:

- `FixedState<N>` = `std::array<double, N>` for compile-time-sized state
- `DynamicState` = `std::vector<double>` for runtime-sized state
- `ParameterizedDerivative<State, Context>` — generic derivative-function signature
  taking an opaque context bundle, never inspected by the framework

`State4D` and `State6D` are now aliases to `FixedState<N>`, preserving
source-compatibility for all existing call sites.

### Projectile physics now use an opaque context

Adds `struct ProjectileContext { double g; double k_over_m; }` in
`derivative_functions.hpp`, with
`using ProjectileDerivative = ParameterizedDerivative<State4D, ProjectileContext>`.

All five physics models (`drag_deriv_v_squared`, `drag_deriv_linear`, `no_drag_deriv`,
`golf_ball_drag_deriv`, `variable_drag_deriv`) refactored to take
`const ProjectileContext& ctx` instead of positional `(double g, double k_over_m)`.

`Simulation` internally constructs a `ProjectileContext` for the stepper binding; the
public constructor signature stays unchanged so call sites don't move.

The old `DerivativeFuncPtr` typedef is removed from `types.hpp` (it was
projectile-specific and lives now in `derivative_functions.hpp` as
`ProjectileDerivative`). Result: `types.hpp` is now fully projectile-neutral. Any
future problem domain can define its own `Context` struct and its own derivative alias
in its own header without touching the framework.

### Integrators are size-portable across array and vector

Stage temporaries in every integrator switch from default-construction to
copy-initialization from the input state:

```cpp
// Before:                          // After:
State deriv;                        State deriv = state;
State k1, k2, k3, k4, temp;         State k1 = state, k2 = state, /*...*/;
State k[7];                         State k[7]; for (auto& ki : k) ki = state;
```

For `std::array<double, N>`, the copy is a small fixed-size operation that gets
overwritten before any read; under `-O3` the compiler elides it. Verified: no
measurable runtime difference vs. default-construct across 5 runs of
`compare_integrators` on a 2.1M-step Euler workload.

For `std::vector<double>`, the assignment sizes the container correctly so the
subsequent `[i] = ...` writes are well-defined. Without this, vector-backed states
segfault on the first integrator call.

### Per-step heap allocation eliminated for vector-backed states

Each integrator's stage temporaries are now `thread_local` inside the function: one
set per thread per template instantiation, lazily sized from the input state on first
call, then reused across subsequent calls. Pattern:

```cpp
template<typename State, typename DerivativeFunc>
State rk4_step(const State& state, double t, double dt, DerivativeFunc deriv_func) {
    thread_local State k1, k2, k3, k4, temp;
    if (k1.size() != state.size()) { k1 = state; k2 = state; /*...*/ }
    // ... four RK4 stages, unchanged ...
}
```

For `std::vector<double>`-backed states this eliminates per-step heap allocation of
the stage workspace — the dominant cost on that path. Measured speedups in
`compare_integrators` (mean of 5 runs):

| Integrator | Before | After   | Speedup |
|---|---|---|---|
| Euler | 181.7 ms | 114.4 ms | 1.59× |
| Heun  |   2.47 ms |   1.04 ms | 2.4× |
| RK4   |   0.508 ms |   0.190 ms | 2.7× |
| RK45  |   0.718 ms |   0.281 ms | 2.6× |
| RK8   |   0.468 ms |   0.221 ms | 2.1× |

Speedup magnitude correlates with stage count — the more stage temporaries an
integrator has, the more allocations the pattern eliminates per step.

For `std::array<double, N>`-backed states, `k1.size() != state.size()` folds to a
compile-time `false` and the conditional initialization becomes dead code under `-O3`.
Runtime unchanged within noise.

**Public API of each integrator is unchanged.** Callers still write
`state = rk4_step(state, t, dt, deriv)`. No workspace struct, no swap pattern,
no caller-side bookkeeping.

Choice of `thread_local` over `static` is intentional: in a single-threaded program
the two are functionally interchangeable, but `static` would be a silent data race
the moment any caller introduces threading (e.g., parameter sweeps, N-body force
parallelization). `thread_local` provides identical single-threaded behavior while
remaining correct under concurrent use.

### Empirical convergence-order measurement

New `test_convergence` executable (`src/test_convergence.cpp`) directly measures the
empirical order of convergence for each fixed-step integrator. The same smooth v² drag
projectile is integrated to a fixed t=T at progressively halved dt values; the global
position error at t=T is compared against an ultra-precise RK8 reference (dt=1e-6),
and `log2(error_prev / error_curr)` is reported per row — the empirical order estimate.

Per-integrator dt sequences are tuned to keep error well above the floating-point
precision floor for several halvings, so each integrator's asymptotic behavior is
visible before the floor sets in.

Best asymptotic empirical orders on this smooth-drag problem:

| Integrator | Theoretical | Empirical | Notes |
|---|---|---|---|
| Euler | 1 | 1.00 | clean across all 5 halvings |
| Heun  | 2 | 2.01 | trends to theoretical asymptotically |
| RK4   | 4 | 4.02 | clean across the dt range |
| RK45 (fixed) | 5 | 5.80 | super-convergence at moderate dt; trending toward 5 |
| RK8   | 8 | 7.94 | clean for 2 halvings, then floating-point floor |

This artifact complements `compare_integrators` (compute cost at a fixed target
precision) by providing a separate, principled measurement of the methods' theoretical
convergence properties.

### README refresh

- Clarifies that RK45 ships as two distinct functions (`rk45_step` fixed-step,
  `rk45_adaptive_step` with embedded error estimation)
- Adds RK4 to the consistency-test description (matches what `test.cpp` actually
  exercises; the sample output already showed it)
- Documents four executables previously missing from the walkthrough:
  `test_golf_ball`, `test_convergence`, `test_adaptive`, `example_3d_motion`
- Adds matching manual-compile commands for those four, verified working

## Verification

All nine executables build clean and produce numerically identical results on this
branch vs. main:

- `./main` → 34.737258° / 246.274544 m
- `./test` → all four test suites pass, per-row angle/distance values unchanged
- `./compare_integrators` → identical step counts and dt values
  (Euler 2,156,009 / Heun 14,309 / RK4 1,787 / RK45 1,568 / RK8 429)
- `./compare_k_over_m` → all 28 rows identical
- `./test_golf_ball`, `./test_variable_drag_supersonic`, `./test_adaptive`,
  `./example_3d_motion` — all match prior runs
- `./test_convergence` → empirical orders recover theoretical values (see table above)

Each cross-cutting change (size-portability, thread_local workspace) was separately
validated by temporarily aliasing `State4D` and `State6D` to `DynamicState`
(`std::vector<double>`) and re-running the full suite — all executables produced
identical numerics, confirming the framework genuinely works with both container
shapes end-to-end.

## API impact

- **No public API breakage**: all existing call sites compile unchanged. The
  `Simulation` constructor signature is preserved; callers continue to pass
  `(k_over_m, integrator, v0, derivative, g, h0)` and the class handles the new
  context-based binding internally.
- **One renamed type**: `DerivativeFuncPtr` → `ProjectileDerivative`. Three internal
  files needed updates (`test.cpp`, `test_golf_ball.cpp`, `test_adaptive.cpp`).
  No external/library API impact.
- **Two new public types**: `FixedState<N>` and `DynamicState`. Existing code
  continues to use `State4D` and `State6D` (now aliases to `FixedState<N>`).

## Files changed

**Headers**
- `include/types.hpp` — new generic aliases, removed projectile-specific `DerivativeFuncPtr`
- `include/derivative_functions.hpp` — `ProjectileContext`, `ProjectileDerivative`,
  updated function declarations
- `include/integrators.hpp` — `= state` initialization, thread_local workspace, file-level
  comment rewritten to describe the new pattern
- `include/simulation.hpp` — constructor parameter type updated

**Sources**
- `src/derivative_functions.cpp` — five physics models migrated to ProjectileContext
- `src/simulation.cpp` — internal stepper builds ProjectileContext
- `src/compare_integrators.cpp` — bound derivative uses ProjectileContext
- `src/test.cpp` — `DerivativeInfo::func` typed as `ProjectileDerivative`
- `src/test_golf_ball.cpp` — `run_optimization_case` parameter type updated
- `src/test_adaptive.cpp` — constructs `ProjectileContext` for derivative binding
- `src/test_convergence.cpp` — **new** — empirical convergence-order test

**Build**
- `CMakeLists.txt` — adds the `test_convergence` target

**Documentation**
- `README.md` — refreshed for accuracy and completeness; documents the four
  previously-undocumented executables

## Deferred for future work

The thread_local workspace pattern eliminates *stage* allocations but not the
*return-value* allocation (`next_state`, or `result.state` and `result.error` in
`rk45_adaptive_step`). For `DynamicState`-backed integrators, RK4 is now ~1.2× slower
than `FixedState` — down from ~3× before the thread_local change — but a small gap
remains, attributable to return-value allocation, TLS access overhead, and cache
locality of heap-backed vector storage.

Closing this gap would require an out-parameter API variant
(`void rk4_step(state, t, dt, deriv, next_state)`) with caller-managed destination,
which was deliberately not done here to preserve the integrators' academic clarity
(no caller-side workspace bookkeeping, no swap pattern at call sites). When a real
DynamicState workload appears that needs the optimization, it can be added as a
parallel API alongside the existing return-by-value form.
